### PR TITLE
AOB-599: Handles tag metadata incrementation

### DIFF
--- a/tests/spec/Domain/Common/TagSpec.php
+++ b/tests/spec/Domain/Common/TagSpec.php
@@ -54,6 +54,16 @@ class TagSpec extends ObjectBehavior
         $nextTag->getVcsTag()->shouldReturn('v4.2.2');
     }
 
+    function it_proposes_the_next_tag_with_metadata()
+    {
+        $this->beConstructedThrough('fromGenericTag', ['4.2.1-02']);
+
+        $nextTag = $this->nextTag();
+
+        $nextTag->shouldBeAnInstanceOf(Tag::class);
+        $nextTag->getVcsTag()->shouldReturn('v4.2.1-03');
+    }
+
     function it_returns_the_corresponding_vcs_branch()
     {
         $this->beConstructedThrough('fromGenericTag', ['4.2.1']);
@@ -92,16 +102,43 @@ class TagSpec extends ObjectBehavior
         $this->beConstructedThrough('fromGenericTag', ['foobar']);
 
         $this->shouldThrow(new \InvalidArgumentException(
-            'The tag must correspond to a patch version (i.e. "4.2.1", "10.0.0"), "foobar" provided.'
+            'The tag must respect Semantic Versioning with, optionally, two digits metadata (6.6.6-01), "foobar" provided.'
         ))->duringInstantiation();
     }
 
-    function it_throws_an_exception_if_the_branch_name_is_not_a_patch_version()
+    function it_throws_an_exception_if_the_tag_does_not_respect_semantic_versioning()
     {
         $this->beConstructedThrough('fromGenericTag', ['10']);
 
         $this->shouldThrow(new \InvalidArgumentException(
-            'The tag must correspond to a patch version (i.e. "4.2.1", "10.0.0"), "10" provided.'
+            'The tag must respect Semantic Versioning with, optionally, two digits metadata (6.6.6-01), "10" provided.'
+        ))->duringInstantiation();
+    }
+
+    function it_throws_an_exception_if_the_tag_metadata_are_less_than_two_digits()
+    {
+        $this->beConstructedThrough('fromGenericTag', ['4.2.0-1']);
+
+        $this->shouldThrow(new \InvalidArgumentException(
+            'The tag must respect Semantic Versioning with, optionally, two digits metadata (6.6.6-01), "4.2.0-1" provided.'
+        ))->duringInstantiation();
+    }
+
+    function it_throws_an_exception_if_the_tag_metadata_are_more_than_two_digits()
+    {
+        $this->beConstructedThrough('fromGenericTag', ['4.2.0-666']);
+
+        $this->shouldThrow(new \InvalidArgumentException(
+            'The tag must respect Semantic Versioning with, optionally, two digits metadata (6.6.6-01), "4.2.0-666" provided.'
+        ))->duringInstantiation();
+    }
+
+    function it_throws_an_exception_if_the_tag_metadata_are_not_digits()
+    {
+        $this->beConstructedThrough('fromGenericTag', ['4.2.0-beta']);
+
+        $this->shouldThrow(new \InvalidArgumentException(
+            'The tag must respect Semantic Versioning with, optionally, two digits metadata (6.6.6-01), "4.2.0-beta" provided.'
         ))->duringInstantiation();
     }
 }

--- a/tests/spec/Domain/Vcs/TagsSpec.php
+++ b/tests/spec/Domain/Vcs/TagsSpec.php
@@ -181,6 +181,24 @@ JSON;
         $tag->getVcsTag()->shouldReturn('v1.1.11');
     }
 
+    function it_uses_natural_sorting_to_find_the_next_tag_with_metadata()
+    {
+        $this->beConstructedThrough('fromListTagsApiResponse', [[
+            ['name' => 'v1.1.0-01'],
+            ['name' => 'v1.1.1-01'],
+            ['name' => 'v1.1.1-02'],
+            ['name' => 'v1.1.1-03'],
+            ['name' => 'v1.1.10-01'],
+            ['name' => 'v1.1.10-02'],
+            ['name' => 'v1.1.2-01'],
+        ]]);
+
+        $tag = $this->nextTagForBranch(new Branch('1.1'));
+
+        $tag->shouldBeAnInstanceOf(Tag::class);
+        $tag->getVcsTag()->shouldReturn('v1.1.10-03');
+    }
+
     function it_returns_the_first_tag_of_a_new_branch()
     {
         $this->beConstructedThrough('fromListTagsApiResponse', [


### PR DESCRIPTION
## Description

Patoche is already capable to propose the next tag, using the last existing one for the branche we are going to tag from. For instance, if we are going to tag the branch `2.0`, and the last `2.0` tag is `2.0.2`, Patoche will propose `2.0.3`.

However, Patoche will also handle PIM Enterprise Cloud pull requests, preparing it for a new tag. PEC uses tags with metadata, like `3.0.10-01`. **PEC tags metadata are always 2 digits**.

Thanks to this PR, Patoche is able to handle this kind of tag and will propose `3.0.10-02` as the next tag. 
As the next tag is a `Tag` value object, it is self validated and will refuse a more than 2 digits metadata (for instance, if we try to tag `x.y.z-100`, should we manage to come to such extremities :trollface:).

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | OK
| Acceptance tests  | -
| Integration tests | -
| Documentation     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
