### PR TITLE
TIP-1252 Removes Circle CI Docker Layer Caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
     setup:
         machine:
             enabled: true
-            docker_layer_caching: true
         environment:
             CURRENT_IDS: "1001:1002"
         steps:
@@ -42,7 +41,6 @@ jobs:
     test:
         machine:
             enabled: true
-            docker_layer_caching: true
         environment:
             CURRENT_IDS: "1001:1002"
         steps:


### PR DESCRIPTION
## Description

This removes the deprecated and extra expensive Circle CI docker layer caching.

## Definition Of Done

| Q                 | A
| ------------------| ---
| Specifications    | -
| Acceptance tests  | -
| Integration tests | -
| Documentation     | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
