### PR TITLE
Issue 52: Make the CircleCI API calls in parallel

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: true,
     node: true,
+    es6: true,
   },
   extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:prettier/recommended'],
   parserOptions: {


### PR DESCRIPTION
This allows to go from 40 seconds to 10 seconds to fetch 5 pages of pipelines.

The trick is to replace
```javascript
for (const workflow of workflows.items) { ... }
``` 
with
```javascript
await Promise.all(workflows.items.map(async (workflow) => { ... }));
```